### PR TITLE
fix: Handle paths more correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,17 @@ Example:
 ```go
 import "github.com/gekkowrld/go-gitconfig"
 
-username, err := gogitconfig.GetValue("user.name", "/path/to/repo") // For a specific starting point
-if err != nil {
-    fmt.Print(err)
+// The struct to be passed.
+// The required field is ConfigKey
+// all the others (well 2) are optional
+myConfig := OptionsPassed{
+    LookupStartLocation: "/path/to/repo", // Adjust this path as needed
+    ConfigLevel:         0, 
+    ConfigKey:           "user.name",
 }
 
-email, err := gogitconfig.GetValue("user.email") // For when no specific location is required
-if err != nil {
-    fmt.Print(err)
-}
+// Call the function with the test case
+username, err := gogitconfig.GetValue(myConfig)
 
-fmt.Printf("Your git username is %s\nYour git Email is %s", username, email)
+fmt.Printf("Your git username is %s\n", username)
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import "github.com/gekkowrld/go-gitconfig"
 // all the others (well 2) are optional
 myConfig := OptionsPassed{
     LookupStartLocation: "/path/to/repo", // Adjust this path as needed
-    ConfigLevel:         0, 
+    ConfigLevel:         0,
     ConfigKey:           "user.name",
 }
 

--- a/gitconfig.go
+++ b/gitconfig.go
@@ -17,9 +17,10 @@ import (
 
 // Options Passed
 // Set:
-//     - the startiing location
-//     - the config key e.g user.key
-//     - the config level
+//   - the startiing location
+//   - the config key e.g user.key
+//   - the config level
+//
 // The config level is one of this values:
 //   - 1 -> "local"
 //   - 2 -> "global"
@@ -27,16 +28,16 @@ import (
 //   - not set -> whichever comes first
 //   - 0 and any other number -> whichever comes first
 type OptionsPassed struct {
-    LookupStartLocation string
-    ConfigLevel         int
-    ConfigKey           string
+	LookupStartLocation string
+	ConfigLevel         int
+	ConfigKey           string
 }
 
 // The var for use as "normal"
 var optsEntered struct {
-    LookupStartLocation string
-    ConfigLevel         int
-    ConfigKey           string
+	LookupStartLocation string
+	ConfigLevel         int
+	ConfigKey           string
 }
 
 // BUG(gekkowrld): Can't handle windows paths yet.
@@ -48,54 +49,54 @@ var optsEntered struct {
 // No error is returned if any of the configuration files don't exist or have an error.
 // An error is only returned when the key is not found.
 func GetValue(optsPassed OptionsPassed) (string, error) {
-    // Instantiate the configLocation
-    configLocation, _ := os.Getwd()
+	// Instantiate the configLocation
+	configLocation, _ := os.Getwd()
 
-    // Override it if there is the startingPoint is actually set
-    if optsPassed.LookupStartLocation != ""{
-        // Take only the first part of the input in case the user passed excess
-        configLocation = optsPassed.LookupStartLocation
-    }
+	// Override it if there is the startingPoint is actually set
+	if optsPassed.LookupStartLocation != "" {
+		// Take only the first part of the input in case the user passed excess
+		configLocation = optsPassed.LookupStartLocation
+	}
 
-    // Check if a user passed in a file or a directory.
-    // If not directory, return the parent directory
-    // Don't do any error checking for now.
-    isUserDir := directoryExists(configLocation)
-    if !isUserDir {
-        configLocation = filepath.Dir(configLocation)
-    }
+	// Check if a user passed in a file or a directory.
+	// If not directory, return the parent directory
+	// Don't do any error checking for now.
+	isUserDir := directoryExists(configLocation)
+	if !isUserDir {
+		configLocation = filepath.Dir(configLocation)
+	}
 
-    // BUG: Not my bug but worth mentioning:
-    // The filepath.Dir() doesn't play nice with Windows.
-    // So there may be some problems with that if it happens
-    // to run on windows.
+	// BUG: Not my bug but worth mentioning:
+	// The filepath.Dir() doesn't play nice with Windows.
+	// So there may be some problems with that if it happens
+	// to run on windows.
 
-    optsEntered.LookupStartLocation = configLocation
-    optsEntered.ConfigLevel = optsPassed.ConfigLevel
-    optsEntered.ConfigKey = optsPassed.ConfigKey
-    return dealWithLevels()
+	optsEntered.LookupStartLocation = configLocation
+	optsEntered.ConfigLevel = optsPassed.ConfigLevel
+	optsEntered.ConfigKey = optsPassed.ConfigKey
+	return dealWithLevels()
 }
 
 // Check the user entered number and use it to
 // call the relevant function(s)
-func dealWithLevels() (string, error){
-    var level int
-    var confKey string
-    level = optsEntered.ConfigLevel
-    confKey = optsEntered.ConfigKey
+func dealWithLevels() (string, error) {
+	var level int
+	var confKey string
+	level = optsEntered.ConfigLevel
+	confKey = optsEntered.ConfigKey
 
-    if level == 1 {
-	    local_file := configLevelFile("local")
-    	return  getConfig(confKey, local_file)
-    } else if level == 2 {
-	    global_file := configLevelFile("global")
-    	return  getConfig(confKey, global_file)
-    } else if level == 3 {
-	    system_file := configLevelFile("system")
-    	return getConfig(confKey, system_file)
-    } else {
-        return callConfRecursively(confKey)
-    }
+	if level == 1 {
+		local_file := configLevelFile("local")
+		return getConfig(confKey, local_file)
+	} else if level == 2 {
+		global_file := configLevelFile("global")
+		return getConfig(confKey, global_file)
+	} else if level == 3 {
+		system_file := configLevelFile("system")
+		return getConfig(confKey, system_file)
+	} else {
+		return callConfRecursively(confKey)
+	}
 }
 
 /* The following methods are not exported, for internal usage */
@@ -162,7 +163,6 @@ func fileExists(fileName string) bool {
 	}
 	return !info.IsDir()
 }
-
 
 // findGitRoot recursively works its way up from the location specified.
 // If it reaches the root directory before it gets a hit, it returns an error.

--- a/gitconfig.go
+++ b/gitconfig.go
@@ -15,8 +15,29 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-// Global Starting point location, DON'T EDIT IT!
-var LookupStartLocation string
+// Options Passed
+// Set:
+//     - the startiing location
+//     - the config key e.g user.key
+//     - the config level
+// The config level is one of this values:
+//   - 1 -> "local"
+//   - 2 -> "global"
+//   - 3 -> "system"
+//   - not set -> whichever comes first
+//   - 0 and any other number -> whichever comes first
+type OptionsPassed struct {
+    LookupStartLocation string
+    ConfigLevel         int
+    ConfigKey           string
+}
+
+// The var for use as "normal"
+var optsEntered struct {
+    LookupStartLocation string
+    ConfigLevel         int
+    ConfigKey           string
+}
 
 // BUG(gekkowrld): Can't handle windows paths yet.
 
@@ -26,18 +47,55 @@ var LookupStartLocation string
 // The value is searched from the local configuration file upwards.
 // No error is returned if any of the configuration files don't exist or have an error.
 // An error is only returned when the key is not found.
-func GetValue(configKey string, startingPoint ...string) (string, error) {
-	// Instantiate the configLocation
-	configLocation, _ := os.Getwd()
+func GetValue(optsPassed OptionsPassed) (string, error) {
+    // Instantiate the configLocation
+    configLocation, _ := os.Getwd()
 
-	// Overide it if there is the startingPoint is actually set
-	if len(startingPoint) >= 1 {
-		// Take only the fist part of the input incase the user passed excess
-		configLocation = startingPoint[0]
-	}
+    // Override it if there is the startingPoint is actually set
+    if optsPassed.LookupStartLocation != ""{
+        // Take only the first part of the input in case the user passed excess
+        configLocation = optsPassed.LookupStartLocation
+    }
 
-	LookupStartLocation = configLocation
-	return callConfRecursively(configKey)
+    // Check if a user passed in a file or a directory.
+    // If not directory, return the parent directory
+    // Don't do any error checking for now.
+    isUserDir := directoryExists(configLocation)
+    if !isUserDir {
+        configLocation = filepath.Dir(configLocation)
+    }
+
+    // BUG: Not my bug but worth mentioning:
+    // The filepath.Dir() doesn't play nice with Windows.
+    // So there may be some problems with that if it happens
+    // to run on windows.
+
+    optsEntered.LookupStartLocation = configLocation
+    optsEntered.ConfigLevel = optsPassed.ConfigLevel
+    optsEntered.ConfigKey = optsPassed.ConfigKey
+    return dealWithLevels()
+}
+
+// Check the user entered number and use it to
+// call the relevant function(s)
+func dealWithLevels() (string, error){
+    var level int
+    var confKey string
+    level = optsEntered.ConfigLevel
+    confKey = optsEntered.ConfigKey
+
+    if level == 1 {
+	    local_file := configLevelFile("local")
+    	return  getConfig(confKey, local_file)
+    } else if level == 2 {
+	    global_file := configLevelFile("global")
+    	return  getConfig(confKey, global_file)
+    } else if level == 3 {
+	    system_file := configLevelFile("system")
+    	return getConfig(confKey, system_file)
+    } else {
+        return callConfRecursively(confKey)
+    }
 }
 
 /* The following methods are not exported, for internal usage */
@@ -47,7 +105,7 @@ func GetValue(configKey string, startingPoint ...string) (string, error) {
 // No error is returned, consider an empty sting an error.
 // BUG(gekkowrld): Can't get system configuration, I have to figure out how to get $(prefix)
 func configLevelFile(level string) string {
-	configStartingLocation := LookupStartLocation
+	configStartingLocation := optsEntered.LookupStartLocation
 
 	// For files to be used/returned
 	var localLocation string
@@ -104,6 +162,7 @@ func fileExists(fileName string) bool {
 	}
 	return !info.IsDir()
 }
+
 
 // findGitRoot recursively works its way up from the location specified.
 // If it reaches the root directory before it gets a hit, it returns an error.


### PR DESCRIPTION
The previous handling had problems with handling paths that ended in files instead of directories.
This has been resolved as of now.

The method for feeding data to the program now is a struct instead of strings (and array of strings).
The struct requires:

- The starting location
- The key to be lookedup
- The level to be searched.

For now system is still not functional as I have yet to find what `$(prefix)` means.
Should be coming soon, (a guess)